### PR TITLE
Refactor asset handover and transfer components to update column labe…

### DIFF
--- a/lib/screen/asset_handover/widget/asset_handover_list.dart
+++ b/lib/screen/asset_handover/widget/asset_handover_list.dart
@@ -129,7 +129,8 @@ class _AssetHandoverListState extends State<AssetHandoverList> {
     columnOptions = [
       ColumnDisplayOption(
         id: 'permission_signing',
-        label: 'Quyền ký',
+        // label: 'Quyền ký',
+        label: 'Trạng thái ký',
         isChecked: visibleColumnIds.contains('permission_signing'),
       ),
       ColumnDisplayOption(
@@ -139,7 +140,8 @@ class _AssetHandoverListState extends State<AssetHandoverList> {
       ),
       ColumnDisplayOption(
         id: 'signing_status',
-        label: 'Trạng thái ký',
+        label: 'Quyền ký',
+        // label: 'Trạng thái ký',
         isChecked: visibleColumnIds.contains('signing_status'),
       ),
       ColumnDisplayOption(
@@ -214,7 +216,8 @@ class _AssetHandoverListState extends State<AssetHandoverList> {
         case 'permission_signing':
           columns.add(
             TableBaseConfig.columnWidgetBase<AssetHandoverDto>(
-              title: 'Quyền ký',
+              // title: 'Quyền ký',
+              title: 'Trạng thái ký',
               cellBuilder:
                   (item) => AppUtility.showPermissionSigning(
                     getPermissionSigning(item),
@@ -261,7 +264,8 @@ class _AssetHandoverListState extends State<AssetHandoverList> {
         case 'signing_status':
           columns.add(
             TableBaseConfig.columnWidgetBase<AssetHandoverDto>(
-              title: 'Trạng thái ký',
+              // title: 'Trạng thái ký',
+              title: 'Quyền ký',
               cellBuilder: (item) => showSigningStatus(item),
               width: 150,
               searchValueGetter: (item) {

--- a/lib/screen/asset_transfer/widget/dieu_dong_tai_san_list.dart
+++ b/lib/screen/asset_transfer/widget/dieu_dong_tai_san_list.dart
@@ -225,7 +225,8 @@ class _DieuDongTaiSanListState extends State<DieuDongTaiSanList> {
         case 'permission_signing':
           columns.add(
             TableBaseConfig.columnWidgetBase<DieuDongTaiSanDto>(
-              title: 'Quyền ký',
+              // title: 'Quyền ký',
+              title: 'Trạng thái ký',
               cellBuilder:
                   (item) => AppUtility.showPermissionSigning(
                     getPermissionSigning(item),
@@ -272,7 +273,8 @@ class _DieuDongTaiSanListState extends State<DieuDongTaiSanList> {
         case 'signing_status':
           columns.add(
             SgTableColumn<DieuDongTaiSanDto>(
-              title: 'Trạng thái ký',
+              // title: 'Trạng thái ký',
+              title: 'Quyền ký',
               cellBuilder: (item) => showSigningStatus(item),
               searchValueGetter: (item) {
                 final status = widget.provider.isCheckSigningStatus(item);

--- a/lib/screen/report/widget/bien_ban_kiem_ke_ccdc_screen.dart
+++ b/lib/screen/report/widget/bien_ban_kiem_ke_ccdc_screen.dart
@@ -39,8 +39,8 @@ class _BienBanKiemKeCcdcScreenState extends State<BienBanKiemKeCcdcScreen> {
   PhongBan? donVi;
   bool _isLoading = false;
   bool _isExporting = false;
-  int numberPageStart = 5;
-  int numberPage = 17;
+  int numberPageStart = 6;
+  int numberPage = 18;
 
   @override
   void initState() {

--- a/lib/screen/tool_and_material_transfer/widget/tool_and_material_transfer_list.dart
+++ b/lib/screen/tool_and_material_transfer/widget/tool_and_material_transfer_list.dart
@@ -137,7 +137,8 @@ class _ToolAndMaterialTransferListState
     columnOptions = [
       ColumnDisplayOption(
         id: 'permission_signing',
-        label: 'Quyền ký',
+        // label: 'Quyền ký',
+        label: 'Trạng thái ký',
         isChecked: visibleColumnIds.contains('permission_signing'),
       ),
       ColumnDisplayOption(
@@ -147,6 +148,7 @@ class _ToolAndMaterialTransferListState
       ),
       ColumnDisplayOption(
         id: 'signing_status',
+        // label: 'Quyền ký'',
         label: 'Trạng thái ký',
         isChecked: visibleColumnIds.contains('signing_status'),
       ),
@@ -222,7 +224,8 @@ class _ToolAndMaterialTransferListState
         case 'permission_signing':
           columns.add(
             TableBaseConfig.columnWidgetBase<ToolAndMaterialTransferDto>(
-              title: 'Quyền ký',
+              // title: 'Quyền ký',
+              title: 'Trạng thái ký',
               cellBuilder:
                   (item) => AppUtility.showPermissionSigning(
                     getPermissionSigning(item),
@@ -269,7 +272,8 @@ class _ToolAndMaterialTransferListState
         case 'signing_status':
           columns.add(
             TableBaseConfig.columnWidgetBase<ToolAndMaterialTransferDto>(
-              title: 'Trạng thái ký',
+              // title: 'Trạng thái ký',
+              title: 'Quyền ký',
               cellBuilder: (item) => showSigningStatus(item),
               width: 150,
               searchValueGetter: (item) {

--- a/lib/screen/tool_and_supplies_handover/widget/tool_and_supplies_handover_list.dart
+++ b/lib/screen/tool_and_supplies_handover/widget/tool_and_supplies_handover_list.dart
@@ -127,7 +127,8 @@ class _ToolAndSuppliesHandoverListState
     columnOptions = [
       ColumnDisplayOption(
         id: 'permission_signing',
-        label: 'Quyền ký',
+        // label: 'Quyền ký',
+        label: 'Trạng thái ký',
         isChecked: visibleColumnIds.contains('permission_signing'),
       ),
       ColumnDisplayOption(
@@ -137,7 +138,8 @@ class _ToolAndSuppliesHandoverListState
       ),
       ColumnDisplayOption(
         id: 'signing_status',
-        label: 'Trạng thái ký',
+        label: 'Quyền ký',
+        // label: 'Trạng thái ký',
         isChecked: visibleColumnIds.contains('signing_status'),
       ),
       ColumnDisplayOption(
@@ -207,7 +209,8 @@ class _ToolAndSuppliesHandoverListState
         case 'permission_signing':
           columns.add(
             TableBaseConfig.columnWidgetBase<ToolAndSuppliesHandoverDto>(
-              title: 'Quyền ký',
+              // title: 'Quyền ký',
+              title: 'Trạng thái ký',
               cellBuilder:
                   (item) => AppUtility.showPermissionSigning(
                     getPermissionSigning(item),
@@ -254,7 +257,8 @@ class _ToolAndSuppliesHandoverListState
         case 'signing_status':
           columns.add(
             TableBaseConfig.columnWidgetBase<ToolAndSuppliesHandoverDto>(
-              title: 'Trạng thái ký',
+              // title: 'Trạng thái ký',
+              title: 'Quyền ký',
               cellBuilder: (item) => showSigningStatus(item),
               width: 150,
               searchValueGetter: (item) {


### PR DESCRIPTION
…ls for clarity

- Changed column label from 'Quyền ký' to 'Trạng thái ký' in asset handover, asset transfer, tool and material transfer, and tool and supplies handover lists.
- Updated corresponding title references in the respective widget files for consistency.